### PR TITLE
Scala 2.12 CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jdk:
 script:
   - sbt ++$TRAVIS_SCALA_VERSION validate
   - sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+  - sbt + package
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: scala
 scala:
-   - 2.11.8
+   - 2.12.1
 jdk:
    - oraclejdk8
 


### PR DESCRIPTION
Updates for CI to allow builds with 2.12.1.